### PR TITLE
fix:Update README.md

### DIFF
--- a/Dockerfile.provided.al2023
+++ b/Dockerfile.provided.al2023
@@ -1,0 +1,16 @@
+FROM scratch
+ADD x86_64/329d91f479ba9976dc72092a57213bb43b5c1eb72a166cd82a1f5d4799f8f33d.tar.xz /
+ADD x86_64/74073c677946b7b00c11623e068c55298d2a8b36faa0e988c7059d40ba810811.tar.xz /
+ADD x86_64/a62f60141b6543af150bfa4e1176d578c02a19f899ef8203de88ba580f6a195a.tar.xz /
+ADD x86_64/dea12ef0c9d750a965b379c66b1fe650de282c27bf8569342d87c1bcd0725530.tar.xz /
+
+ENV LANG=en_US.UTF-8
+ENV TZ=:/etc/localtime
+ENV PATH=/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin
+ENV LD_LIBRARY_PATH=/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib
+ENV LAMBDA_TASK_ROOT=/var/task
+ENV LAMBDA_RUNTIME_DIR=/var/runtime
+
+WORKDIR /var/task
+
+ENTRYPOINT ["/lambda-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ eg. to build the `nodejs18.x` image, start by checking out the `nodejs18.x` bran
 ```
 git checkout nodejs18.x
 ```
+fetch the large files
+```
+git lfs fetch
+git lfs install
+git lfs checkout .
+```
 
 Finally you can build your image as such:
 ```

--- a/arm64/4900c9096e62e0a011c7c2da7a61184c74bfab190cb740d82be4cbe25b7267e6.tar.xz
+++ b/arm64/4900c9096e62e0a011c7c2da7a61184c74bfab190cb740d82be4cbe25b7267e6.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83e9abf614e95ae2079f55a7fb2ca18e85590cf3d33dba7903f5a8e1914e73b0
+size 468

--- a/arm64/6fdfa36fec0e4083ed6f52cfb84f277f5e9c46283f8696b92a1c1347908ead4a.tar.xz
+++ b/arm64/6fdfa36fec0e4083ed6f52cfb84f277f5e9c46283f8696b92a1c1347908ead4a.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7595a5cd3ab31245cd6c9a4d76edb9807587ac044498366af9f1e040fe84bb7e
+size 44296

--- a/arm64/85e2bc4ddc961338b7b72d52481e234d1eee24a6b16d8e9ba53a21a62de79664.tar.xz
+++ b/arm64/85e2bc4ddc961338b7b72d52481e234d1eee24a6b16d8e9ba53a21a62de79664.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0f6a4036f506d539e41453fe1c2424cf9657e57f246cd346b6f69018e429d48
+size 22461160

--- a/arm64/Dockerfile.provided.al2023
+++ b/arm64/Dockerfile.provided.al2023
@@ -1,0 +1,17 @@
+FROM scratch
+
+ADD 4900c9096e62e0a011c7c2da7a61184c74bfab190cb740d82be4cbe25b7267e6.tar.xz /
+ADD 6fdfa36fec0e4083ed6f52cfb84f277f5e9c46283f8696b92a1c1347908ead4a.tar.xz /
+ADD 85e2bc4ddc961338b7b72d52481e234d1eee24a6b16d8e9ba53a21a62de79664.tar.xz /
+ADD b2252d5148f232de50331e8816ec8717671feb0e503fecb0cccc9a6e32b27f3e.tar.xz /
+
+ENV LANG=en_US.UTF-8
+ENV TZ=:/etc/localtime
+ENV PATH=/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin
+ENV LD_LIBRARY_PATH=/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib
+ENV LAMBDA_TASK_ROOT=/var/task
+ENV LAMBDA_RUNTIME_DIR=/var/runtime
+
+WORKDIR /var/task
+
+ENTRYPOINT ["/lambda-entrypoint.sh"]

--- a/arm64/b2252d5148f232de50331e8816ec8717671feb0e503fecb0cccc9a6e32b27f3e.tar.xz
+++ b/arm64/b2252d5148f232de50331e8816ec8717671feb0e503fecb0cccc9a6e32b27f3e.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e2cc230393a4ad022ea86a2eb650d3ceb05906405d57660ccd0038f2d76f1a
+size 1736740

--- a/x86_64/329d91f479ba9976dc72092a57213bb43b5c1eb72a166cd82a1f5d4799f8f33d.tar.xz
+++ b/x86_64/329d91f479ba9976dc72092a57213bb43b5c1eb72a166cd82a1f5d4799f8f33d.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8b519dd16fb7a48e44f6437515206e70fa5948c185e9d07ed50dd29517a1fe9
+size 44268

--- a/x86_64/74073c677946b7b00c11623e068c55298d2a8b36faa0e988c7059d40ba810811.tar.xz
+++ b/x86_64/74073c677946b7b00c11623e068c55298d2a8b36faa0e988c7059d40ba810811.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a6490ab9ed7ffeb354236fb4737ccff894f164d40d94380670b7ebde07fc640
+size 2014336

--- a/x86_64/Dockerfile.provided.al2023
+++ b/x86_64/Dockerfile.provided.al2023
@@ -1,0 +1,17 @@
+FROM scratch
+
+ADD 329d91f479ba9976dc72092a57213bb43b5c1eb72a166cd82a1f5d4799f8f33d.tar.xz /
+ADD 74073c677946b7b00c11623e068c55298d2a8b36faa0e988c7059d40ba810811.tar.xz /
+ADD a62f60141b6543af150bfa4e1176d578c02a19f899ef8203de88ba580f6a195a.tar.xz /
+ADD dea12ef0c9d750a965b379c66b1fe650de282c27bf8569342d87c1bcd0725530.tar.xz /
+
+ENV LANG=en_US.UTF-8
+ENV TZ=:/etc/localtime
+ENV PATH=/var/lang/bin:/usr/local/bin:/usr/bin/:/bin:/opt/bin
+ENV LD_LIBRARY_PATH=/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/var/task/lib:/opt/lib
+ENV LAMBDA_TASK_ROOT=/var/task
+ENV LAMBDA_RUNTIME_DIR=/var/runtime
+
+WORKDIR /var/task
+
+ENTRYPOINT ["/lambda-entrypoint.sh"]

--- a/x86_64/a62f60141b6543af150bfa4e1176d578c02a19f899ef8203de88ba580f6a195a.tar.xz
+++ b/x86_64/a62f60141b6543af150bfa4e1176d578c02a19f899ef8203de88ba580f6a195a.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:357ad22b42f406c7489834b7459ecf386b42f3d14ec8e4929b95606676d6539a
+size 468

--- a/x86_64/dea12ef0c9d750a965b379c66b1fe650de282c27bf8569342d87c1bcd0725530.tar.xz
+++ b/x86_64/dea12ef0c9d750a965b379c66b1fe650de282c27bf8569342d87c1bcd0725530.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89e8a3454b0e11fc4038c69941656f51c8a9efd2306512185509dc3185cb4552
+size 24188360


### PR DESCRIPTION
add large file before building the docker image

The original instruction in readme ignore the large file download and would build empty docker image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
