### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ eg. to build the `nodejs18.x` image, start by checking out the `nodejs18.x` bran
 ```
 git checkout nodejs18.x
 ```
+fetch the large files
+```
+git lfs fetch
+git lfs install
+git lfs checkout .
+```
 
 Finally you can build your image as such:
 ```


### PR DESCRIPTION
Fetch the large file before building the image.

The current instructions on readme would omit the large size file and build a empty image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
